### PR TITLE
removed caching from test environment and fixed rubocop errors

### DIFF
--- a/app/facades/background_facade.rb
+++ b/app/facades/background_facade.rb
@@ -2,7 +2,6 @@
 
 # facade for backgrounds
 class BackgroundFacade
-
   def initialize(location)
     @location = location
   end
@@ -20,5 +19,4 @@ class BackgroundFacade
   def service_data
     @_service_data ||= service.city_image(@location)
   end
-
 end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -2,7 +2,6 @@
 
 # facade for forecasts
 class ForecastFacade
-
   def initialize(location)
     @location = location
   end
@@ -55,5 +54,4 @@ class ForecastFacade
   def service_data
     @_service_data ||= service.weather_data
   end
-
 end

--- a/app/facades/road_trip_facade.rb
+++ b/app/facades/road_trip_facade.rb
@@ -2,7 +2,6 @@
 
 # facade for road trip
 class RoadTripFacade
-
   def initialize(start, ending)
     @start = start
     @ending = ending
@@ -26,5 +25,4 @@ class RoadTripFacade
   def geocode_service
     GoogleGeocodeService.new
   end
-
 end

--- a/app/models/background.rb
+++ b/app/models/background.rb
@@ -21,5 +21,4 @@ class Background
   def background_facade
     BackgroundFacade.new(@location)
   end
-
 end

--- a/app/services/dark_sky_service.rb
+++ b/app/services/dark_sky_service.rb
@@ -23,7 +23,7 @@ class DarkSkyService
   def weather_data
     lat = find_lat
     long = find_long
-    Rails.cache.fetch("#{lat},#{long}", :expires_in => 15.minutes) do
+    Rails.cache.fetch("#{lat},#{long}", expires_in: 15.minutes) do
       response = conn.get('/forecast/'\
         "#{ENV['DARKSKY_KEY']}/#{lat},#{long}")
       JSON.parse(response.body, symbolize_names: true)

--- a/app/services/google_geocode_service.rb
+++ b/app/services/google_geocode_service.rb
@@ -9,7 +9,7 @@ class GoogleGeocodeService
   end
 
   def find_coords(location)
-    Rails.cache.fetch("#{location}", :expires_in => 15.minutes) do
+    Rails.cache.fetch("#{location}", expires_in: 15.minutes) do
       formatted_address = format_address(location)
       response = conn.get('/maps/api/geocode/'\
         "json?key=#{ENV['GOOGLE_API_KEY']}&address=#{formatted_address}")
@@ -18,9 +18,10 @@ class GoogleGeocodeService
   end
 
   def get_time(start, ending)
-    Rails.cache.fetch("#{start},#{ending}", :expires_in => 15.minutes) do
+    Rails.cache.fetch("#{start},#{ending}", expires_in: 15.minutes) do
       response = conn.get('/maps/api/directions/'\
-        "json?origin=#{start}&destination=#{ending}&key=#{ENV['GOOGLE_API_KEY']}")
+        "json?origin=#{start}&destination=#{ending}"\
+        "&key=#{ENV['GOOGLE_API_KEY']}")
       results = JSON.parse(response.body, symbolize_names: true)
       results[:routes][0][:legs][0][:duration][:value]
     end

--- a/app/services/pixabay_service.rb
+++ b/app/services/pixabay_service.rb
@@ -9,7 +9,7 @@ class PixabayService
   end
 
   def city_image(location)
-    Rails.cache.fetch("#{location}", :expires_in => 60.minutes) do
+    Rails.cache.fetch("#{location}", expires_in: 60.minutes) do
       city = edited_location(location)
       response = conn.get("/api/?key=#{ENV['PIXABAY_KEY']}&q=#{city}&tags=city")
       JSON.parse(response.body, symbolize_names: true)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,6 +24,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
+  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
- [] Wrote Tests
- [x] Implemented
- [] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

# Implements/Fixes: caching in test environment
## Description of Changes: Set caching to false and cache store to null for test environment.  SimpleCov had been showing a drop in services test coverage after caching was enabled.  Setting these variables in the test environment disabled the caching and brought the services test coverage back up.  Also fixed some rubocop violations.

closes #

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code

# Test Coverage:

- Overall coverage: 99.44%
- Model coverage: 100%
- Services coverage: 96.9%
- Linter coverage: 10 offenses
